### PR TITLE
Rename variables in Google Analytics code

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,10 +14,10 @@
   <link rel='canonical' href='{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}'>
   <link rel='alternate' type='application/rss+xml' title='{{ site.title }}' href='{{ '/feed.xml' | prepend: site.baseurl | prepend: site.url }}' />
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    !function(g,i,t,h,u,b){g.GoogleAnalyticsObject=t;g[t]||(g[t]=function(){
+    (g[t].q=g[t].q||[]).push(arguments)});g[t].l=+new Date;u=i.createElement(h);
+    b=i.getElementsByTagName(h)[0];u.src='//www.google-analytics.com/analytics.js';
+    b.parentNode.insertBefore(u,b)}(window,document,'ga','script');
 
     ga('create', 'UA-3769691-57', 'auto');
     ga('send', 'pageview');


### PR DESCRIPTION
`i` `s` `o` `g` `r` `a` `m` -> `g` `i` `t` `h` `u` `b`

The code is generated by using [isogram](https://github.com/shinnn/isogram), a well-tested Google Analytics code generator used in [github/choosealicense.com](https://github.com/github/choosealicense.com) and [a lot of other websites](https://github.com/shinnn/isogram/tree/8ac7cd1b13f363af96af8bd32fd055e2ca720e3a#websites-using-isogram).

If you prefer other characters, I'll update this commit. For example:

`e` `l` `e` `c` `t`

```js
!function(E,l,e,c,t){E.GoogleAnalyticsObject=e;E[e]||(E[e]=function(){
(E[e].q=E[e].q||[]).push(arguments)});E[e].l=+new Date;c=l.createElement('script');
t=l.scripts[0];c.src='//www.google-analytics.com/analytics.js';
t.parentNode.insertBefore(c,t)}(window,document,'ga');

ga('create', 'UA-3769691-57', 'auto');
ga('send', 'pageview');
```

`A` `T` `O` `M` `i` `o`

```js
!function(A,T,O,M,i,o){A.GoogleAnalyticsObject=O;A[O]||(A[O]=function(){
(A[O].q=A[O].q||[]).push(arguments)});A[O].l=+new Date;i=T.createElement(M);
o=T.getElementsByTagName(M)[0];i.src='//www.google-analytics.com/analytics.js';
o.parentNode.insertBefore(i,o)}(window,document,'ga','script');

ga('create', 'UA-3769691-57', 'auto');
ga('send', 'pageview');
```