### PR TITLE
Add link checker grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 .sass-cache
 node_modules/
+npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,19 @@
+module.exports = function(grunt) {
+  grunt.loadNpmTasks('grunt-link-checker');
+
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+
+    linkChecker: {
+      options: {
+        maxConcurrency: 100
+      },
+      dev: {
+        site: 'localhost',
+        options: {
+          initialPort: 4000
+        }
+      }
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "yamljs": "^0.2.3"
   },
   "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-link-checker": "^0.1.0",
     "tap-spec": "^4.0.0",
     "tape": "^4.0.0"
   }


### PR DESCRIPTION
You can run `grunt linkChecker` to see any broken links.

We can eventually wire this into CI.

/cc @jlord 