### PR TITLE
Update Internal Links v0.27.0

### DIFF
--- a/_docs/latest/api/browser-window.md
+++ b/_docs/latest/api/browser-window.md
@@ -23,7 +23,7 @@ win.show();
 ```
 
 You can also create a window without chrome by using
-[Frameless Window](frameless-window.md) API.
+[Frameless Window](../frameless-window) API.
 
 ## Class: BrowserWindow
 
@@ -55,11 +55,11 @@ You can also create a window without chrome by using
     zoom percent / 100, so `3.0` represents `300%`
   * `kiosk` Boolean - The kiosk mode
   * `title` String - Default window title
-  * `icon` [NativeImage](native-image.md) - The window icon, when omitted on
+  * `icon` [NativeImage](../native-image) - The window icon, when omitted on
     Windows the executable's icon would be used as window icon
   * `show` Boolean - Whether window should be shown when created
   * `frame` Boolean - Specify `false` to create a
-    [Frameless Window](frameless-window.md)
+    [Frameless Window](../frameless-window)
   * `node-integration` Boolean - Whether node integration is enabled, default
     is `true`
   * `accept-first-mouse` Boolean - Whether the web view accepts a single
@@ -75,7 +75,7 @@ You can also create a window without chrome by using
     scripts run in the window. This script will always have access to node APIs
     no matter whether node integration is turned on for the window, and the path
     of `preload` script has to be absolute path.
-  * `transparent` Boolean - Makes the window [transparent](frameless-window.md)
+  * `transparent` Boolean - Makes the window [transparent](../frameless-window)
   * `type` String - Specifies the type of the window, possible types are
     `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
     Linux.
@@ -550,11 +550,11 @@ Opens the developer tools for the service worker context present in the web cont
 
 Captures the snapshot of page within `rect`, upon completion `callback` would be
 called with `callback(image)`, the `image` is an instance of
-[NativeImage](native-image.md) that stores data of the snapshot. Omitting the
+[NativeImage](../native-image) that stores data of the snapshot. Omitting the
 `rect` would capture the whole visible page.
 
 **Note:** Be sure to read documents on remote buffer in
-[remote](remote.md) if you are going to use this API in renderer
+[remote](../remote) if you are going to use this API in renderer
 process.
 
 ### BrowserWindow.print([options])
@@ -605,7 +605,7 @@ it will assume `app.getName().desktop`.
 
 ### BrowserWindow.setOverlayIcon(overlay, description)
 
-* `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
+* `overlay` [NativeImage](../native-image) - the icon to display on the bottom
 right corner of the Taskbar icon. If this parameter is `null`, the overlay is
 cleared
 * `description` String - a description that will be provided to Accessibility

--- a/_docs/latest/api/clipboard.md
+++ b/_docs/latest/api/clipboard.md
@@ -41,11 +41,11 @@ Writes the `text` into clipboard as plain text.
 
 * `type` String
 
-Returns the content in clipboard as [NativeImage](native-image.md).
+Returns the content in clipboard as [NativeImage](../native-image).
 
 ## clipboard.writeImage(image[, type])
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 * `type` String
 
 Writes the `image` into clipboard.

--- a/_docs/latest/api/dialog.md
+++ b/_docs/latest/api/dialog.md
@@ -83,7 +83,7 @@ would be passed via `callback(filename)`
   * `title` String - Title of the message box, some platforms will not show it
   * `message` String - Content of the message box
   * `detail` String - Extra information of the message
-  * `icon` [NativeImage](native-image.md)
+  * `icon` [NativeImage](../native-image)
 * `callback` Function
 
 Shows a message box, it will block until the message box is closed. It returns

--- a/_docs/latest/api/frameless-window.md
+++ b/_docs/latest/api/frameless-window.md
@@ -12,7 +12,7 @@ A frameless window is a window that has no chrome.
 ## Create a frameless window
 
 To create a frameless window, you only need to specify `frame` to `false` in
-[BrowserWindow](browser-window.md)'s `options`:
+[BrowserWindow](../browser-window)'s `options`:
 
 
 ```javascript

--- a/_docs/latest/api/global-shortcut.md
+++ b/_docs/latest/api/global-shortcut.md
@@ -31,7 +31,7 @@ globalShortcut.unregisterAll();
 
 ## globalShortcut.register(accelerator, callback)
 
-* `accelerator` [Accelerator](accelerator.md)
+* `accelerator` [Accelerator](../accelerator)
 * `callback` Function
 
 Registers a global shortcut of `accelerator`, the `callback` would be called when
@@ -39,13 +39,13 @@ the registered shortcut is pressed by user.
 
 ## globalShortcut.isRegistered(accelerator)
 
-* `accelerator` [Accelerator](accelerator.md)
+* `accelerator` [Accelerator](../accelerator)
 
 Returns whether shortcut of `accelerator` is registered.
 
 ## globalShortcut.unregister(accelerator)
 
-* `accelerator` [Accelerator](accelerator.md)
+* `accelerator` [Accelerator](../accelerator)
 
 Unregisters the global shortcut of `keycode`.
 

--- a/_docs/latest/api/ipc-renderer.md
+++ b/_docs/latest/api/ipc-renderer.md
@@ -10,9 +10,9 @@ source_url: 'https://github.com/atom/electron/blob/master/docs/api/ipc-renderer.
 The `ipc` module provides a few methods so you can send synchronous and
 asynchronous messages to the main process, and also receive messages sent from
 main process. If you want to make use of modules of main process from renderer
-process, you might consider using the [remote](remote.md) module.
+process, you might consider using the [remote](../remote) module.
 
-See [ipc (main process)](ipc-main-process.md) for examples.
+See [ipc (main process)](../ipc-main-process) for examples.
 
 ## ipc.send(channel[, args...])
 

--- a/_docs/latest/api/menu-item.md
+++ b/_docs/latest/api/menu-item.md
@@ -19,8 +19,8 @@ source_url: 'https://github.com/atom/electron/blob/master/docs/api/menu-item.md'
      `radio`
   * `label` String
   * `sublabel` String
-  * `accelerator` [Accelerator](accelerator.md)
-  * `icon` [NativeImage](native-image.md)
+  * `accelerator` [Accelerator](../accelerator)
+  * `icon` [NativeImage](../native-image)
   * `enabled` Boolean
   * `visible` Boolean
   * `checked` Boolean

--- a/_docs/latest/api/menu.md
+++ b/_docs/latest/api/menu.md
@@ -12,7 +12,7 @@ application menus and context menus. Each menu consists of multiple menu
 items, and each menu item can have a submenu.
 
 Below is an example of creating a menu dynamically in a web page by using
-the [remote](remote.md) module, and showing it when the user right clicks
+the [remote](../remote) module, and showing it when the user right clicks
 the page:
 
 ```html
@@ -194,7 +194,7 @@ emulating default Cocoa menu behaviors, usually you would just use the
 * `template` Array
 
 Generally, the `template` is just an array of `options` for constructing
-[MenuItem](menu-item.md), the usage can be referenced above.
+[MenuItem](../menu-item), the usage can be referenced above.
 
 You can also attach other fields to element of the `template`, and they will
 become properties of the constructed menu items.

--- a/_docs/latest/api/remote.md
+++ b/_docs/latest/api/remote.md
@@ -142,7 +142,7 @@ Returns the object returned by `require(module)` in the main process.
 
 ## remote.getCurrentWindow()
 
-Returns the [BrowserWindow](browser-window.md) object which this web page
+Returns the [BrowserWindow](../browser-window) object which this web page
 belongs to.
 
 ## remote.getCurrentWebContent()

--- a/_docs/latest/api/synopsis.md
+++ b/_docs/latest/api/synopsis.md
@@ -9,7 +9,7 @@ source_url: 'https://github.com/atom/electron/blob/master/docs/api/synopsis.md'
 
 All of [node.js's built-in modules](http://nodejs.org/api/) are available in
 Electron, and third-party node modules are fully supported too (including the
-[native modules](../tutorial/using-native-node-modules.md)).
+[native modules](../../tutorial/using-native-node-modules)).
 
 Electron also provides some extra built-in modules for developing native
 desktop applications. Some modules are only available on the main process, some

--- a/_docs/latest/api/tray.md
+++ b/_docs/latest/api/tray.md
@@ -47,7 +47,7 @@ rely on `clicked` event and always attach a context menu to the tray icon.
 
 ### new Tray(image)
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 
 Creates a new tray icon associated with the `image`.
 
@@ -95,13 +95,13 @@ Destroys the tray icon immediately.
 
 ### Tray.setImage(image)
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 
 Sets the `image` associated with this tray icon.
 
 ### Tray.setPressedImage(image)
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 
 Sets the `image` associated with this tray icon when pressed.
 
@@ -130,7 +130,7 @@ __Note:__ This is only implemented on OS X.
 ### Tray.displayBalloon(options)
 
 * `options` Object
-  * `icon` [NativeImage](native-image.md)
+  * `icon` [NativeImage](../native-image)
   * `title` String
   * `content` String
 

--- a/_docs/latest/tutorial/application-distribution.md
+++ b/_docs/latest/tutorial/application-distribution.md
@@ -58,7 +58,7 @@ electron/resources/
 └── app.asar
 ```
 
-More details can be found in [Application packaging](application-packaging.md).
+More details can be found in [Application packaging](../application-packaging).
 
 ## Rebranding with downloaded binaries
 

--- a/_docs/latest/tutorial/quick-start.md
+++ b/_docs/latest/tutorial/quick-start.md
@@ -45,9 +45,9 @@ native GUI resources in web pages is very dangerous and easy to leak resources.
 If you want to do GUI operations in web pages, you have to communicate with
 the main process to do it there.
 
-In Electron, we have provided the [ipc](../api/ipc-renderer.md) module for
+In Electron, we have provided the [ipc](../../api/ipc-renderer) module for
 communication between main process and renderer process. And there is also a
-[remote](../api/remote.md) module for RPC style communication.
+[remote](../../api/remote) module for RPC style communication.
 
 ## Write your first Electron app
 
@@ -134,7 +134,7 @@ Finally the `index.html` is the web page you want to show:
 ## Run your app
 
 After you're done writing your app, you can create a distribution by
-following the [Application distribution](./application-distribution.md) guide
+following the [Application distribution](../application-distribution) guide
 and then execute the packaged app. You can also just use the downloaded
 Electron binary to execute your app directly.
 

--- a/_docs/v0.27.0/api/browser-window.md
+++ b/_docs/v0.27.0/api/browser-window.md
@@ -23,7 +23,7 @@ win.show();
 ```
 
 You can also create a window without chrome by using
-[Frameless Window](frameless-window.md) API.
+[Frameless Window](../frameless-window) API.
 
 ## Class: BrowserWindow
 
@@ -55,11 +55,11 @@ You can also create a window without chrome by using
     zoom percent / 100, so `3.0` represents `300%`
   * `kiosk` Boolean - The kiosk mode
   * `title` String - Default window title
-  * `icon` [NativeImage](native-image.md) - The window icon, when omitted on
+  * `icon` [NativeImage](../native-image) - The window icon, when omitted on
     Windows the executable's icon would be used as window icon
   * `show` Boolean - Whether window should be shown when created
   * `frame` Boolean - Specify `false` to create a
-    [Frameless Window](frameless-window.md)
+    [Frameless Window](../frameless-window)
   * `node-integration` Boolean - Whether node integration is enabled, default
     is `true`
   * `accept-first-mouse` Boolean - Whether the web view accepts a single
@@ -75,7 +75,7 @@ You can also create a window without chrome by using
     scripts run in the window. This script will always have access to node APIs
     no matter whether node integration is turned on for the window, and the path
     of `preload` script has to be absolute path.
-  * `transparent` Boolean - Makes the window [transparent](frameless-window.md)
+  * `transparent` Boolean - Makes the window [transparent](../frameless-window)
   * `type` String - Specifies the type of the window, possible types are
     `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
     Linux.
@@ -550,11 +550,11 @@ Opens the developer tools for the service worker context present in the web cont
 
 Captures the snapshot of page within `rect`, upon completion `callback` would be
 called with `callback(image)`, the `image` is an instance of
-[NativeImage](native-image.md) that stores data of the snapshot. Omitting the
+[NativeImage](../native-image) that stores data of the snapshot. Omitting the
 `rect` would capture the whole visible page.
 
 **Note:** Be sure to read documents on remote buffer in
-[remote](remote.md) if you are going to use this API in renderer
+[remote](../remote) if you are going to use this API in renderer
 process.
 
 ### BrowserWindow.print([options])
@@ -605,7 +605,7 @@ it will assume `app.getName().desktop`.
 
 ### BrowserWindow.setOverlayIcon(overlay, description)
 
-* `overlay` [NativeImage](native-image.md) - the icon to display on the bottom
+* `overlay` [NativeImage](../native-image) - the icon to display on the bottom
 right corner of the Taskbar icon. If this parameter is `null`, the overlay is
 cleared
 * `description` String - a description that will be provided to Accessibility

--- a/_docs/v0.27.0/api/clipboard.md
+++ b/_docs/v0.27.0/api/clipboard.md
@@ -41,11 +41,11 @@ Writes the `text` into clipboard as plain text.
 
 * `type` String
 
-Returns the content in clipboard as [NativeImage](native-image.md).
+Returns the content in clipboard as [NativeImage](../native-image).
 
 ## clipboard.writeImage(image[, type])
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 * `type` String
 
 Writes the `image` into clipboard.

--- a/_docs/v0.27.0/api/dialog.md
+++ b/_docs/v0.27.0/api/dialog.md
@@ -83,7 +83,7 @@ would be passed via `callback(filename)`
   * `title` String - Title of the message box, some platforms will not show it
   * `message` String - Content of the message box
   * `detail` String - Extra information of the message
-  * `icon` [NativeImage](native-image.md)
+  * `icon` [NativeImage](../native-image)
 * `callback` Function
 
 Shows a message box, it will block until the message box is closed. It returns

--- a/_docs/v0.27.0/api/frameless-window.md
+++ b/_docs/v0.27.0/api/frameless-window.md
@@ -12,7 +12,7 @@ A frameless window is a window that has no chrome.
 ## Create a frameless window
 
 To create a frameless window, you only need to specify `frame` to `false` in
-[BrowserWindow](browser-window.md)'s `options`:
+[BrowserWindow](../browser-window)'s `options`:
 
 
 ```javascript

--- a/_docs/v0.27.0/api/global-shortcut.md
+++ b/_docs/v0.27.0/api/global-shortcut.md
@@ -31,7 +31,7 @@ globalShortcut.unregisterAll();
 
 ## globalShortcut.register(accelerator, callback)
 
-* `accelerator` [Accelerator](accelerator.md)
+* `accelerator` [Accelerator](../accelerator)
 * `callback` Function
 
 Registers a global shortcut of `accelerator`, the `callback` would be called when
@@ -39,13 +39,13 @@ the registered shortcut is pressed by user.
 
 ## globalShortcut.isRegistered(accelerator)
 
-* `accelerator` [Accelerator](accelerator.md)
+* `accelerator` [Accelerator](../accelerator)
 
 Returns whether shortcut of `accelerator` is registered.
 
 ## globalShortcut.unregister(accelerator)
 
-* `accelerator` [Accelerator](accelerator.md)
+* `accelerator` [Accelerator](../accelerator)
 
 Unregisters the global shortcut of `keycode`.
 

--- a/_docs/v0.27.0/api/ipc-renderer.md
+++ b/_docs/v0.27.0/api/ipc-renderer.md
@@ -10,9 +10,9 @@ source_url: 'https://github.com/atom/electron/blob/master/docs/api/ipc-renderer.
 The `ipc` module provides a few methods so you can send synchronous and
 asynchronous messages to the main process, and also receive messages sent from
 main process. If you want to make use of modules of main process from renderer
-process, you might consider using the [remote](remote.md) module.
+process, you might consider using the [remote](../remote) module.
 
-See [ipc (main process)](ipc-main-process.md) for examples.
+See [ipc (main process)](../ipc-main-process) for examples.
 
 ## ipc.send(channel[, args...])
 

--- a/_docs/v0.27.0/api/menu-item.md
+++ b/_docs/v0.27.0/api/menu-item.md
@@ -19,8 +19,8 @@ source_url: 'https://github.com/atom/electron/blob/master/docs/api/menu-item.md'
      `radio`
   * `label` String
   * `sublabel` String
-  * `accelerator` [Accelerator](accelerator.md)
-  * `icon` [NativeImage](native-image.md)
+  * `accelerator` [Accelerator](../accelerator)
+  * `icon` [NativeImage](../native-image)
   * `enabled` Boolean
   * `visible` Boolean
   * `checked` Boolean

--- a/_docs/v0.27.0/api/menu.md
+++ b/_docs/v0.27.0/api/menu.md
@@ -12,7 +12,7 @@ application menus and context menus. Each menu consists of multiple menu
 items, and each menu item can have a submenu.
 
 Below is an example of creating a menu dynamically in a web page by using
-the [remote](remote.md) module, and showing it when the user right clicks
+the [remote](../remote) module, and showing it when the user right clicks
 the page:
 
 ```html
@@ -194,7 +194,7 @@ emulating default Cocoa menu behaviors, usually you would just use the
 * `template` Array
 
 Generally, the `template` is just an array of `options` for constructing
-[MenuItem](menu-item.md), the usage can be referenced above.
+[MenuItem](../menu-item), the usage can be referenced above.
 
 You can also attach other fields to element of the `template`, and they will
 become properties of the constructed menu items.

--- a/_docs/v0.27.0/api/remote.md
+++ b/_docs/v0.27.0/api/remote.md
@@ -142,7 +142,7 @@ Returns the object returned by `require(module)` in the main process.
 
 ## remote.getCurrentWindow()
 
-Returns the [BrowserWindow](browser-window.md) object which this web page
+Returns the [BrowserWindow](../browser-window) object which this web page
 belongs to.
 
 ## remote.getCurrentWebContent()

--- a/_docs/v0.27.0/api/synopsis.md
+++ b/_docs/v0.27.0/api/synopsis.md
@@ -9,7 +9,7 @@ source_url: 'https://github.com/atom/electron/blob/master/docs/api/synopsis.md'
 
 All of [node.js's built-in modules](http://nodejs.org/api/) are available in
 Electron, and third-party node modules are fully supported too (including the
-[native modules](../tutorial/using-native-node-modules.md)).
+[native modules](../../tutorial/using-native-node-modules)).
 
 Electron also provides some extra built-in modules for developing native
 desktop applications. Some modules are only available on the main process, some

--- a/_docs/v0.27.0/api/tray.md
+++ b/_docs/v0.27.0/api/tray.md
@@ -47,7 +47,7 @@ rely on `clicked` event and always attach a context menu to the tray icon.
 
 ### new Tray(image)
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 
 Creates a new tray icon associated with the `image`.
 
@@ -95,13 +95,13 @@ Destroys the tray icon immediately.
 
 ### Tray.setImage(image)
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 
 Sets the `image` associated with this tray icon.
 
 ### Tray.setPressedImage(image)
 
-* `image` [NativeImage](native-image.md)
+* `image` [NativeImage](../native-image)
 
 Sets the `image` associated with this tray icon when pressed.
 
@@ -130,7 +130,7 @@ __Note:__ This is only implemented on OS X.
 ### Tray.displayBalloon(options)
 
 * `options` Object
-  * `icon` [NativeImage](native-image.md)
+  * `icon` [NativeImage](../native-image)
   * `title` String
   * `content` String
 

--- a/_docs/v0.27.0/tutorial/application-distribution.md
+++ b/_docs/v0.27.0/tutorial/application-distribution.md
@@ -58,7 +58,7 @@ electron/resources/
 └── app.asar
 ```
 
-More details can be found in [Application packaging](application-packaging.md).
+More details can be found in [Application packaging](../application-packaging).
 
 ## Rebranding with downloaded binaries
 

--- a/_docs/v0.27.0/tutorial/quick-start.md
+++ b/_docs/v0.27.0/tutorial/quick-start.md
@@ -45,9 +45,9 @@ native GUI resources in web pages is very dangerous and easy to leak resources.
 If you want to do GUI operations in web pages, you have to communicate with
 the main process to do it there.
 
-In Electron, we have provided the [ipc](../api/ipc-renderer.md) module for
+In Electron, we have provided the [ipc](../../api/ipc-renderer) module for
 communication between main process and renderer process. And there is also a
-[remote](../api/remote.md) module for RPC style communication.
+[remote](../../api/remote) module for RPC style communication.
 
 ## Write your first Electron app
 
@@ -134,7 +134,7 @@ Finally the `index.html` is the web page you want to show:
 ## Run your app
 
 After you're done writing your app, you can create a distribution by
-following the [Application distribution](./application-distribution.md) guide
+following the [Application distribution](../application-distribution) guide
 and then execute the packaged app. You can also just use the downloaded
 Electron binary to execute your app directly.
 


### PR DESCRIPTION
This runs the fix in https://github.com/atom/electron.atom.io/pull/42 on version 0.27.0 of the docs, fixing the paths to internal links. 