### PR TITLE
Fix doc script assumptions about OS path separator

### DIFF
--- a/lib/doc-links.js
+++ b/lib/doc-links.js
@@ -58,17 +58,17 @@ module.exports = function fixLinks (dir, version, callback) {
       if (href.match(/\.md/ig)) {
         var newLink = href.replace(/\.md/ig, '')
         if (newLink.indexOf('../') > -1) {
-          newLink = 'http://' + path.join(baseUrl, newLink.replace('../', ''))
+          newLink = 'http://' + path.join(baseUrl, newLink.replace('../', '')).split(path.sep).join('/')
           var newMdLink = bracket + '(' + newLink + ')'
           return newMdLink
         } else if (newLink.indexOf('./') > -1) {
           var fileDir = getFileDir(file)
-          newLink = 'http://' + path.join(baseUrl, fileDir, newLink)
+          newLink = 'http://' + path.join(baseUrl, fileDir, newLink).split(path.sep).join('/')
           newMdLink = bracket + '(' + newLink + ')'
           return newMdLink
         } else if (newLink.indexOf('/') < 0) {
           fileDir = getFileDir(file)
-          newLink = 'http://' + path.join(baseUrl, fileDir, newLink)
+          newLink = 'http://' + path.join(baseUrl, fileDir, newLink).split(path.sep).join('/')
           newMdLink = bracket + '(' + newLink + ')'
           return newMdLink
         }
@@ -79,11 +79,11 @@ module.exports = function fixLinks (dir, version, callback) {
     replaceLinksInContent(file, content, links, newLinks)
   }
 
-  function getFileDir (path) {
-    var array = path.split('/')
+  function getFileDir (p) {
+    var array = p.split(path.sep)
     return array[array.length - 2]
   }
-
+  
   function replaceLinksInContent (file, content, oldLinks, newLinks) {
     oldLinks.forEach(function (oldLink, i) {
       content = content.replace(oldLink, newLinks[i])

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -63,7 +63,7 @@ function extractDocs (filename, settings, callback) {
 
   var extract = tar.extract(settings.tmpDir, {
     ignore: function (name) {
-      return name.indexOf('/docs/') === -1
+      return name.indexOf(path.sep + 'docs' + path.sep) === -1
     },
     mapStream: function (fileStream, header) {
       var frontmatter
@@ -71,7 +71,7 @@ function extractDocs (filename, settings, callback) {
         var metadata = constructDocMetadata(header.name, settings.version)
         metadata.source_url = constructSourceUrl(header.name)
         if (path.basename(header.name, '.md') === 'README') {
-          metadata.permalink = '/docs/' + settings.version + '/index.html'
+          metadata.permalink = '/' + path.join('docs', settings.version, 'index.html').split(path.sep).join('/')
           frontmatter = new Buffer('---\n' + yaml.stringify(metadata) + '---\n\n')
           return fileStream.pipe(frontMatterify(frontmatter)).pipe(removeMdUrls())
         }
@@ -83,7 +83,7 @@ function extractDocs (filename, settings, callback) {
   })
 
   extract.on('entry', function extracting (header, stream, next) {
-    var extractedElectronDir = header.name.split('/')[0]
+      var extractedElectronDir = header.name.split('/')[0]
     settings.newDir = path.join(settings.tmpDir, extractedElectronDir)
   })
 


### PR DESCRIPTION
The script to fetch docs assumed that the OS path separator is always a forward slash (`/`) and while that works for most *nix-based systems, it was failing on Windows. This PR fixes that by using [`path.sep`](https://nodejs.org/api/path.html#path_path_sep) from Node wherever possible.