### PR TITLE
Releases instructions and link to view all 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ To test the documentation script:
 $ npm test
 ```
 
+#### Release Notes
+
+The most recent release notes from the `atom/electron` repository are made available on the site and can be updated by running:
+
+```bash
+$ script/releases
+```
+
+
+
 ### Contributing
 
 Thanks for contributing to the site! Checkout the [contributing documentation](CONTRIBUTING.md) for guidelines on pull requests.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ The most recent release notes from the `atom/electron` repository are made avail
 $ script/releases
 ```
 
-
-
 ### Contributing
 
 Thanks for contributing to the site! Checkout the [contributing documentation](CONTRIBUTING.md) for guidelines on pull requests.

--- a/_layouts/releases.html
+++ b/_layouts/releases.html
@@ -12,6 +12,7 @@ layout: page
       {% for release in site.data.releases %}
       <span class='jump-to-item'><a href='{{ release.html_url }}'>{{ release.tag_name }}</span></a>
       {% endfor releases %}
+      <span class="jump-to-item"><a href="https://github.com/atom/electron/releases" target="_blank">All Releases</a></span>
 
       </div>
     </div>


### PR DESCRIPTION
This adds instructions for updating the releases info to the readme and on the releases page it now links to view all the releases (on GitHub) since just the latest are shown. 

![screen shot 2015-07-29 at 12 20 25 pm](https://cloud.githubusercontent.com/assets/1305617/8967721/9296a342-35ed-11e5-87f6-553d3da6b70c.png)
