### PR TITLE
Make Quick Start guide more discoverable

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ layout: default
         </div>
         <div class='row'>
           <div class='ten columns offset-by-one'>
-            <h5>Getting started with Electron is easy. Download a <a href='https://github.com/atom/electron/releases'>prebuilt binary</a> or use <a href='https://www.npmjs.com/'>npm</a> to install from the command line. Full documentation is in <a href='https://github.com/atom/electron/tree/master/docs'>the repository</a>.</h5>
+            <h5>Getting started with Electron is easy. Download a <a href='https://github.com/atom/electron/releases'>prebuilt binary</a> or use <a href='https://www.npmjs.com/'>npm</a> to install from the command line, then check out the <a href="http://electron.atom.io/docs/latest/tutorial/quick-start/">Quick Start Guide</a>. Full documentation is in <a href='https://github.com/atom/electron/tree/master/docs'>the repository</a>.</h5>
           </div>
         </div>
         <div class='row'>


### PR DESCRIPTION
When I was first getting started with Electron, I didn't know there was a Quick Start guide and that that was where I should've started. This PR links to the Quick Start guide in the Getting Started section at the bottom of the home page, which will hopefully help to make it a bit more discoverable.

/cc @jlord 