### PR TITLE
Update the Get Started Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ layout: default
         </div>
         <div class='row'>
           <div class='ten columns offset-by-one'>
-            <h5>Getting started with Electron is easy. Download a <a href='https://github.com/atom/electron/releases'>prebuilt binary</a> or use <a href='https://www.npmjs.com/'>npm</a> to install from the command line. Full documentation is in <a href='https://github.com/atom/electron/tree/master/docs'>the repository</a>.</h5>
+            <h5>Download a <a href='https://github.com/atom/electron/releases'>prebuilt binary</a> or use <a href='https://www.npmjs.com/'>npm</a> to install Electron from the command line. Read the <a href="/docs/latest">docs</a> or check out <a href="https://github.com/sindresorhus/awesome-electron" target="_blank">projects and build tools</a> created by the community.</h5>
           </div>
         </div>
         <div class='row'>


### PR DESCRIPTION
This incorporates https://github.com/atom/electron.atom.io/pull/66 which points to the Quick Start Guide and adds a reference to this site's documentation (instead linking to repository) and to @sindresorhus's `awesome-electron` list (linked to by the `atom/electron` readme, too).

![screen shot 2015-07-29 at 1 30 35 pm](https://cloud.githubusercontent.com/assets/1305617/8969147/6e962f5e-35f6-11e5-8d2c-055fd165dba4.png)

cc @mnquintana