### PR TITLE
Add Permalinks to Headers

### DIFF
--- a/_includes/anchor_links.html
+++ b/_includes/anchor_links.html
@@ -1,0 +1,33 @@
+<script>
+  var anchorForId = function (id) {
+    var anchor = document.createElement("a");
+    anchor.className = "header-link";
+    anchor.href      = "#" + id;
+    anchor.innerHTML = "<span class='octicon octicon-link'></span>";
+    anchor.title = "Permalink";
+    return anchor;
+  };
+
+  var linkifyAnchors = function (level, containingElement) {
+    var headers = containingElement.getElementsByTagName("h" + level);
+    for (var h = 0; h < headers.length; h++) {
+      var header = headers[h];
+
+      if (typeof header.id !== "undefined" && header.id !== "") {
+        header.appendChild(anchorForId(header.id));
+      }
+    }
+  };
+
+  document.onreadystatechange = function () {
+    if (this.readyState === "complete") {
+      var contentBlock = document.getElementsByClassName("docs")[0] || document.getElementsByClassName("news")[0];
+      if (!contentBlock) {
+        return;
+      }
+      for (var level = 1; level <= 6; level++) {
+        linkifyAnchors(level, contentBlock);
+      }
+    }
+  };
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
     </div>
 
     {% include footer.html %}
-
+    {% include anchor_links.html %}
   </body>
 
 </html>

--- a/css/main.css
+++ b/css/main.css
@@ -55,6 +55,11 @@ code {
   border: none;
 }
 
+.header-link .octicon {
+  margin-left: 10px;
+  vertical-align: middle;
+}
+
 /* Sections
    ------------------------------------------ */
 


### PR DESCRIPTION
This PR adds the scripts and liquid templates that Jekyll needs to turn headers into _headers with permalinks_. [Info on how here](https://george-hawkins.github.io/basic-gfm-jekyll/redcarpet-extensions.html#hover-anchors).

I'm not :100: on having hidden link icons that you have to hover to see so if no one else hates them I've got them to the right of headers like so:

<img width="417" alt="screen shot 2015-08-11 at 9 03 06 pm" src="https://cloud.githubusercontent.com/assets/1305617/9207529/81f5d39c-406e-11e5-8f2c-8d7cd373f871.png">

Closes https://github.com/atom/electron.atom.io/issues/34