### PR TITLE
[WIP] Docs Style Updates

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,7 @@
   <link rel='stylesheet' href='{{ site.url }}/css/main.css'>
   <link rel='stylesheet' href='{{ site.url }}/css/octicons/octicons.css'>
   <link rel='stylesheet' href='{{ site.url }}/css/pygments.css'>
+  <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:400,700' rel='stylesheet' type='text/css'>
   <link rel='canonical' href='{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}'>
   <link rel='alternate' type='application/rss+xml' title='{{ site.title }}' href='{{ '/feed.xml' | prepend: site.baseurl | prepend: site.url }}' />
   <script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,7 +3,7 @@ layout: page
 ---
 
 <section class='jump-to-release'>
-  <div class='container '>
+  <div class='container'>
     <div class='row'>
       <div class='twelve columns'>
       <h1>Electron Documentation</h1>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -6,7 +6,7 @@ layout: page
   <div class='container'>
     <div class='row'>
       <div class='twelve columns'>
-      <h1>Electron Documentation</h1>
+      <h1><img class="electron-icon" src='/images/electron-icon.svg'>Electron Documentation</h1>
       {% if page.category != 'ignore' %}
       <a href='/docs/{{ page.version }}/'>{{ page.version }} {% if site.latest_version == page.version %} (Latest) {% endif %} </a> |
       <a href='{{ page.source_url }}'>Document Source</a>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -2,7 +2,7 @@
 layout: page
 ---
 
-<section class='jump-to-release'>
+<section class='jump-to-release {% if page.category != "Table of Contents" %}is-compact{% endif %}'>
   <div class='container'>
     <div class='row'>
       <div class='twelve columns'>

--- a/css/main.css
+++ b/css/main.css
@@ -90,6 +90,12 @@ header {
   padding: 12px 0;
   background-color: #76C7D7;
 }
+@media (max-width: 550px) {
+  header,
+  header .text-right  {
+    text-align: center;
+  }
+}
 
 header a {
   color: #FAF7F3;
@@ -187,6 +193,12 @@ header a:hover {
 footer {
   padding: 15px 0;
   background-color: #FAF7F3;
+}
+@media (max-width: 550px) {
+  footer,
+  footer .text-right {
+    text-align: center;
+  }
 }
 
 /* Releases

--- a/css/main.css
+++ b/css/main.css
@@ -214,6 +214,12 @@ footer {
     margin: 0 2rem 0 0;
   }
 }
+.jump-to-release .electron-icon {
+  height: 1.5em;
+  margin-right: 0.4em;
+  margin-top: -0.4em;
+  vertical-align: middle;
+}
 
 .releases {
   background-color: #FAF7F3;

--- a/css/main.css
+++ b/css/main.css
@@ -286,10 +286,9 @@ footer {
 }
 
 .docs h3 code {
-  background-color: transparent;
-  padding: 0;
   margin: 0;
   font-weight: 400;
+  background-color: rgba(57, 174, 198, 0.1);
 }
 
 .docs h3 code + em {

--- a/css/main.css
+++ b/css/main.css
@@ -222,7 +222,7 @@ footer {
 
 .docs {
   background-color: #fff;
-  color: rgba(12, 46, 58, 0.82);
+  color: #39555D;
 }
 
 .docs h1 {
@@ -260,7 +260,7 @@ footer {
 
 .docs pre code,
 .docs code {
-  color: rgba(12, 46, 58, 0.82);
+  color: #38535B;
   border: none;
   background-color: #FAF7F3;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -41,6 +41,7 @@ a.no-hover-dec:hover {
 }
 
 pre, code {
+  font-family: "Source Code Pro", Consolas, "Liberation Mono", Menlo, Courier, monospace;
   text-align: left;
 }
 
@@ -56,6 +57,7 @@ code {
 }
 
 .header-link .octicon {
+  color: #dcd9d6;
   margin-left: 10px;
   vertical-align: middle;
 }
@@ -219,8 +221,9 @@ footer {
    ------------------------------------------ */
 
 .docs {
-     background-color: #FAF7F3;
-   }
+  background-color: #fff;
+  color: rgba(12, 46, 58, 0.82);
+}
 
 .docs h1 {
  font-size: 3em;
@@ -252,10 +255,11 @@ footer {
   padding-right: 8px;
 }
 
-.docs code, .docs pree {
-  color: #076274;
+.docs pre code,
+.docs code {
+  color: rgba(12, 46, 58, 0.82);
   border: none;
-  background-color: #EAE5DE;
+  background-color: #FAF7F3;
 }
 
 .docs blockquote {
@@ -265,4 +269,23 @@ footer {
 
 .all-of-the-latest-documentation h1:first-child {
   padding: 0;
+}
+
+.docs ul {
+  margin-left: 0;
+  text-indent: -1em;
+  padding-left: 1em;
+}
+
+.docs h3,
+.docs h3 code {
+  color: #39AEC6;
+  padding-top: 20px;
+}
+
+.docs h3 code {
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+  font-weight: 400;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -201,6 +201,19 @@ footer {
   text-align: center;
   background: #A5ECFA;
 }
+.jump-to-release.is-compact {
+  padding: 2rem 0;
+}
+.jump-to-release.is-compact h1 {
+  font-size: 1.8em;
+  margin-bottom: 0.2em;
+}
+@media (min-width: 1000px) {
+  .jump-to-release.is-compact h1 {
+    display: inline-block;
+    margin: 0 2rem 0 0;
+  }
+}
 
 .releases {
   background-color: #FAF7F3;

--- a/css/main.css
+++ b/css/main.css
@@ -289,3 +289,15 @@ footer {
   margin: 0;
   font-weight: 400;
 }
+
+.docs h3 code + em {
+  background: #76C7D7;
+  padding: 3px 6px;
+  font-size: 13px;
+  text-transform: uppercase;
+  font-style: normal;
+  font-family: Source Code Pro;
+  border-radius: 2px;
+  color: #fff;
+  vertical-align: middle;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -226,20 +226,23 @@ footer {
 }
 
 .docs h1 {
- font-size: 3em;
- font-weight: 500;
- padding-bottom: 40px;
+  font-size: 3em;
+  font-weight: 500;
+  margin-bottom: 4rem;
 }
 
 .docs h2 {
- font-size: 2em;
- padding-top: 30px;
+  font-size: 2em;
+  margin-top: 4rem;
+  margin-bottom: 2rem;
 }
 
 .docs h3 {
   font-size: 1.5em;
   font-weight: 300;
-  letter-spacing: .001em
+  letter-spacing: .001em;
+  margin-top: 3rem;
+  margin-bottom: 1.5rem;
 }
 
 .docs-breadcumb {
@@ -280,7 +283,6 @@ footer {
 .docs h3,
 .docs h3 code {
   color: #39AEC6;
-  padding-top: 20px;
 }
 
 .docs h3 code {

--- a/css/main.css
+++ b/css/main.css
@@ -266,6 +266,7 @@ footer {
 }
 
 .docs blockquote {
+  color: #557F8B;
   border-left: 1px solid #76C7D7;
   padding-left: 20px;
 }


### PR DESCRIPTION
:construction: 

This PR updates some CSS styles on the documentation pages to improve their layout. 

The documentation changes are currently being made in `atom/electron` which will then be updated here at the next minor version release (once those changes are merged). 

In the meantime, improvements include:

- Colored events and method headers
- Specific callouts to platforms

<img width="577" alt="screen shot 2015-08-22 at 2 59 23 pm" src="https://cloud.githubusercontent.com/assets/1305617/9454050/ecb8c0cc-4a73-11e5-9313-6fbe353088d1.png">

---

It's hard to actually see these changes without the updated docs so I've just been copying and pasting them into here to test. 

cc @simurai :eyes: and :bulb: 
