### PR TITLE
Adds horizontal scrolling to code tag

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -48,11 +48,13 @@ pre code {
   color: #C5F3FC;
   border: none;
   background-color: #076274;
+  overflow-x: scroll;
 }
 
 code {
   background-color: #EAE5DE;
   border: none;
+  overflow-x: scroll; 
 }
 
 .header-link .octicon {


### PR DESCRIPTION
Closes #71 
     Code overflows background area.
Changes: 
     Adds horizontal scrolling to code tag to prevent text from overflowing background area.