### PR TITLE
Display Platform Labels Correctly

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -55,7 +55,7 @@ pre code {
 code {
   background-color: #EAE5DE;
   border: none;
-  overflow-x: scroll; 
+  overflow-x: scroll;
 }
 
 .header-link .octicon {

--- a/css/main.css
+++ b/css/main.css
@@ -325,7 +325,7 @@ footer {
   background-color: rgba(57, 174, 198, 0.1);
 }
 
-.docs h3 code + em {
+.docs h3 code ~ em {
   background: #76C7D7;
   padding: 3px 6px;
   font-size: 13px;

--- a/css/main.css
+++ b/css/main.css
@@ -325,7 +325,8 @@ footer {
   background-color: rgba(57, 174, 198, 0.1);
 }
 
-.docs h3 code ~ em {
+.docs h3 code > em,
+.docs h3 > em {
   background: #76C7D7;
   padding: 3px 6px;
   font-size: 13px;


### PR DESCRIPTION
The correct CSS :sparkles: :tophat: @muan.

This also fixes it in Events which previously weren't getting the style at all. 

Fixes #84 