### PR TITLE
Removed space after links

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,104 +86,79 @@ layout: default
           <hr>
 
           <a href='https://atom.io' target='_blank' title='Atom'>
-            <img class='other-logo' src='../images/atom.png' alt='Atom icon'>
-          </a>
+            <img class='other-logo' src='../images/atom.png' alt='Atom icon'></a>
 
           <a href='https://slack.com' target='_blank' title='Slack'>
-            <img class='other-logo' src='../images/slack.png' alt='Slack icon'>
-          </a>
+            <img class='other-logo' src='../images/slack.png' alt='Slack icon'></a>
 
           <a href='https://code.visualstudio.com' target='_blank' title='Visual Studio Code'>
-            <img class='other-logo' src='../images/vscode.png' alt='Visual Studio Code icon'>
-          </a>
+            <img class='other-logo' src='../images/vscode.png' alt='Visual Studio Code icon'></a>
 
           <a href='http://avocode.com' target='_blank' title='Avocode'>
-            <img class='other-logo' src='../images/avocode.png' alt='Avocode icon'>
-          </a>
+            <img class='other-logo' src='../images/avocode.png' alt='Avocode icon'></a>
 
           <a href='https://www.mapbox.com' target='_blank' title='Mapbox'>
-            <img class='other-logo' src='../images/mapbox.png' alt='Mapbox icon'>
-          </a>
+            <img class='other-logo' src='../images/mapbox.png' alt='Mapbox icon'></a>
 
           <a href='http://nuclide.io' target='_blank' title='Nuclide'>
-            <img class='other-logo' src='../images/nuclide.png' alt='Nuclide icon'>
-          </a>
+            <img class='other-logo' src='../images/nuclide.png' alt='Nuclide icon'></a>
 
           <a href='https://kitematic.com' target='_blank' title='Kitematic'>
-            <img class='other-logo' src='../images/kitematic.png' alt='Kitematic icon'>
-          </a>
+            <img class='other-logo' src='../images/kitematic.png' alt='Kitematic icon'></a>
 
           <a href='http://www.pixate.com' target='_blank' title='Pixate'>
-            <img class='other-logo' src='../images/pixate.png' alt='Pixate icon'>
-          </a>
+            <img class='other-logo' src='../images/pixate.png' alt='Pixate icon'></a>
 
           <a href='http://www.wagonhq.com' target='_blank' title='Wagon'>
-            <img class='other-logo' src='../images/wagon.png' alt='Wagon icon'>
-          </a>
+            <img class='other-logo' src='../images/wagon.png' alt='Wagon icon'></a>
 
           <a href='https://www.particle.io/dev' target='_blank' title='Particle Dev'>
-            <img class='other-logo' src='../images/particle.png' alt='Particle icon'>
-          </a>
+            <img class='other-logo' src='../images/particle.png' alt='Particle icon'></a>
 
           <a href='http://fireball-x.com/en' target='_blank' title='Fireball'>
-            <img class='other-logo' src='../images/fireball.png' alt='Fireball icon'>
-          </a>
+            <img class='other-logo' src='../images/fireball.png' alt='Fireball icon'></a>
 
           <a href='http://speak.io' target='_blank' title='Speak'>
-            <img class='other-logo' src='../images/speak.png' alt='Speak icon'>
-          </a>
+            <img class='other-logo' src='../images/speak.png' alt='Speak icon'></a>
 
           <a href='http://popkey.co/send-gifs' target='_blank' title='PopKey'>
-            <img class='other-logo' src='../images/pop-key.png' alt='PopKey icon'>
-          </a>
+            <img class='other-logo' src='../images/pop-key.png' alt='PopKey icon'></a>
 
           <a href='https://www.jibo.com' target='_blank' title='JIBO'>
-            <img class='other-logo' src='../images/jibo.png' alt='JIBO icon'>
-          </a>
+            <img class='other-logo' src='../images/jibo.png' alt='JIBO icon'></a>
 
           <a href='http://lab.ionic.io' target='_blank' title='Ionic Lab'>
-            <img class='other-logo' src='../images/ionic-lab.png' alt='Ionic Lab icon'>
-          </a>
+            <img class='other-logo' src='../images/ionic-lab.png' alt='Ionic Lab icon'></a>
 
           <a href='https://rocket.chat' target='_blank' title='Rocket.Chat'>
-            <img class='other-logo' src='../images/rocket-chat.png' alt='Rocket.Chat icon'>
-          </a>
+            <img class='other-logo' src='../images/rocket-chat.png' alt='Rocket.Chat icon'></a>
 
           <a href='http://microstockr.com' target='_blank' title='Microstockr'>
-            <img class='other-logo' src='../images/microstockr.png' alt='Microstockr icon'>
-          </a>
+            <img class='other-logo' src='../images/microstockr.png' alt='Microstockr icon'></a>
 
           <a href='https://www.gitbook.com' target='_blank' title='GitBook'>
-            <img class='other-logo' src='../images/gitbook.png' alt='GitBook icon'>
-          </a>
+            <img class='other-logo' src='../images/gitbook.png' alt='GitBook icon'></a>
 
           <a href='https://www.nylas.com/n1' target='_blank' title='Nylas N1'>
-            <img class='other-logo' src='../images/nylas.png' alt='Nylas icon'>
-          </a>
+            <img class='other-logo' src='../images/nylas.png' alt='Nylas icon'></a>
 
           <a href='http://www.gitkraken.com' target='_blank' title='GitKraken'>
-            <img class='other-logo' src='../images/gitkraken.png' alt='GitKraken icon'>
-          </a>
+            <img class='other-logo' src='../images/gitkraken.png' alt='GitKraken icon'></a>
 
           <a href='http://www.airtame.com' target='_blank' title='AIRTAME'>
-            <img class='other-logo' src='../images/airtame.png' alt='AIRTAME icon'>
-          </a>
+            <img class='other-logo' src='../images/airtame.png' alt='AIRTAME icon'></a>
 
           <a href='https://www.spreaker.com/download' target='_blank' title='Spreaker Studio'>
-            <img class='other-logo' src='../images/spreaker-studio.png' alt='Spreaker Studio icon'>
-          </a>
+            <img class='other-logo' src='../images/spreaker-studio.png' alt='Spreaker Studio icon'></a>
 
           <a href='http://www.kakapo.co/app.html#desktop' target='_blank' title='Kakapo'>
-            <img class='other-logo' src='../images/kakapo.png' alt='Kakapo'>
-          </a>
+            <img class='other-logo' src='../images/kakapo.png' alt='Kakapo'></a>
 
           <a href='http://zoommyapp.com' target='_blank' title='Zoommy'>
-            <img class='other-logo' src='../images/zoommy.png' alt='Zoommy'>
-          </a>
+            <img class='other-logo' src='../images/zoommy.png' alt='Zoommy'></a>
 
           <a href='http://www.gitify.io' target='_blank' title='Gitify'>
-            <img class='other-logo' src='../images/gitify.png' alt='Gitify'>
-          </a>
+            <img class='other-logo' src='../images/gitify.png' alt='Gitify'></a>
 
           <hr>
         </div>


### PR DESCRIPTION
The spaces that followed the links triggered an underline after each
image when hovering the images.

I removed the spaces but this messes up the indentation used there. This could also be fixed by adding a class to the div they're all inside and writing a specific CSS rule that removes text decoration for links inside that.