### PR TITLE
Update Get Started with Quick Start Repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,18 +238,23 @@ layout: default
         </div>
         <div class='row'>
           <div class='ten columns offset-by-one'>
-            <h5>Download a <a href='https://github.com/atom/electron/releases'>prebuilt binary</a> or use <a href='https://www.npmjs.com/'>npm</a> to install from the command line, then check out the <a href="http://electron.atom.io/docs/latest/tutorial/quick-start/">Quick Start Guide</a>. Read the <a href="/docs/latest">documentation</a> or check out <a href="https://github.com/sindresorhus/awesome-electron" target="_blank">projects and build tools</a> created by the community.</h5>
+            <h5>Spin up the <a href='https://github.com/atom/electron-quick-start' target='_blank'>Quick Start</a> app to see Electron in action:</h5>
           </div>
         </div>
         <div class='row'>
-          <div class='six columns offset-by-three'>
+          <div class='eight columns offset-by-two'>
             <pre><code>
-# Install the `electron` command globally
-npm install electron-prebuilt -g
+# Clone the Quick Start repository
+git clone https://github.com/atom/electron-quick-start
 
-# Install as a development dependency
-npm install electron-prebuilt --save-dev
+# Install the dependencies and run
+npm install && npm run
             </code></pre>
+          </div>
+        </div>
+        <div class='row'>
+          <div class='ten columns offset-by-one'>
+            <p>You can also checkout the full <a href='http://electron.atom.io/docs/latest/tutorial/quick-start/'>Quick Start Tutorial</a> or download a <a href='https://github.com/atom/electron/releases' target='_blank'>prebuilt binary</a> and read the <a href='/docs/latest'>documentation</a>.</p>
           </div>
         </div>
         </div>


### PR DESCRIPTION
This updates the Get Started section to point people to the Quick Start app:

Before:
<img width="858" alt="screen shot 2015-10-29 at 3 21 17 pm" src="https://cloud.githubusercontent.com/assets/1305617/10835070/0d83aa94-7e5c-11e5-839a-0b0bc261a11f.png">

After:
<img width="829" alt="screen shot 2015-10-29 at 3 36 37 pm" src="https://cloud.githubusercontent.com/assets/1305617/10835071/11f34dd2-7e5c-11e5-920a-cd05bf1c6c14.png">