### PR TITLE
Exclude files not needed from the build process

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,16 @@ collections:
     docs: {output: true, permalink: '/docs/:path/'}
 defaults:
     - {scope: {type: docs}, values: {layout: docs}}
+
+# exclude:
+#   - node_modules
+#   - README.md
+#   - LICENSE.md
+#   - CNAME
+#   - Gemfile
+#   - Gemfile.lock
+#   - Grunfile.js
+#   - package.json
+#   - script
+#   - spec
+# 

--- a/_config.yml
+++ b/_config.yml
@@ -28,15 +28,14 @@ collections:
 defaults:
     - {scope: {type: docs}, values: {layout: docs}}
 
-# exclude:
-#   - node_modules
-#   - README.md
-#   - LICENSE.md
-#   - CNAME
-#   - Gemfile
-#   - Gemfile.lock
-#   - Grunfile.js
-#   - package.json
-#   - script
-#   - spec
-# 
+exclude:
+  - node_modules
+  - README.md
+  - LICENSE.md
+  - CNAME
+  - Gemfile
+  - Gemfile.lock
+  - Grunfile.js
+  - package.json
+  - script
+  - spec


### PR DESCRIPTION
This adds some excludes to Jekyll's config file to speed up the build process, especially `node_modules`, which doesn't appear to be used in the built site (Jekyll won't watch for changes in these folders or try to copy the files over to the site's output directory).

Testing locally, the build time went from about a minute to about 15 seconds.

/cc @jlord 