### PR TITLE
Add Electron, Node, Chromium, V8 Versions to Home Page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ redcarpet:
 gems:
     - jekyll-redirect-from
 latest_version: v0.34.0
+current_node: 4.1.1
+current_chrome: 45.0.2454.85
+current_v8: 4.5.103.29
 available_versions:
     - v0.24.0
     - v0.25.0
@@ -27,15 +30,14 @@ collections:
     docs: {output: true, permalink: '/docs/:path/'}
 defaults:
     - {scope: {type: docs}, values: {layout: docs}}
-
 exclude:
-  - node_modules
-  - README.md
-  - LICENSE.md
-  - CNAME
-  - Gemfile
-  - Gemfile.lock
-  - Grunfile.js
-  - package.json
-  - script
-  - spec
+    - node_modules
+    - README.md
+    - LICENSE.md
+    - CNAME
+    - Gemfile
+    - Gemfile.lock
+    - Grunfile.js
+    - package.json
+    - script
+    - spec

--- a/css/main.css
+++ b/css/main.css
@@ -195,19 +195,23 @@ header a:hover {
 .electron-vers {
   display: inline-block;
   border: 2px solid #448691;
-  padding: 4px 12px 4px 6px;
   margin-bottom: 16px;
   border-radius: 3px;
-  font-family: monospace;
+  font-family: 'Source Code Pro', monospace;
+  font-size: 12px;
+  padding: 0 2px;
 }
 
-.electron-vers span + span {
+.electron-vers span {
+  float: left;
+  display: inline-block;
+  line-height: 1;
   padding: 6px 6px;
 }
 
 .main-ver {
   border-right: 2px solid #448691;
-  padding: 6px 13px 6px 8px;
+  font-weight: bold;
 }
 
 /* Footer

--- a/css/main.css
+++ b/css/main.css
@@ -189,6 +189,27 @@ header a:hover {
 }
 
 
+/* Get Started
+   ------------------------------------------ */
+
+.electron-vers {
+  display: inline-block;
+  border: 2px solid #448691;
+  padding: 4px 12px 4px 6px;
+  margin-bottom: 16px;
+  border-radius: 3px;
+  font-family: monospace;
+}
+
+.electron-vers span + span {
+  padding: 6px 6px;
+}
+
+.main-ver {
+  border-right: 2px solid #448691;
+  padding: 6px 13px 6px 8px;
+}
+
 /* Footer
    ------------------------------------------ */
 

--- a/index.html
+++ b/index.html
@@ -239,9 +239,10 @@ layout: default
         <div class='twelve columns'>
           <h3>Get started with Electron</h3>
           <div class="electron-vers">
-            <span class="main-ver"><b>Electron: {{ site.latest_version }}</b></span>
+            <span class="main-ver">Electron: {{ site.latest_version }}</span>
             <span class="dep-ver">Node: {{ site.current_node }}</span>
             <span class="dep-ver">Chrome: {{ site.current_chrome }}</span>
+            <span class="dep-ver">V8: {{ site.current_v8 }}</span>
           </div>
         </div>
         <div class='row'>

--- a/index.html
+++ b/index.html
@@ -238,6 +238,11 @@ layout: default
       <div class='row'>
         <div class='twelve columns'>
           <h3>Get started with Electron</h3>
+          <div class="electron-vers">
+            <span class="main-ver"><b>Electron: {{ site.latest_version }}</b></span>
+            <span class="dep-ver">Node: {{ site.current_node }}</span>
+            <span class="dep-ver">Chrome: {{ site.current_chrome }}</span>
+          </div>
         </div>
         <div class='row'>
           <div class='ten columns offset-by-one'>

--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@ layout: default
           <div class="electron-vers">
             <span class="main-ver">Electron: {{ site.latest_version }}</span>
             <span class="dep-ver">Node: {{ site.current_node }}</span>
-            <span class="dep-ver">Chrome: {{ site.current_chrome }}</span>
+            <span class="dep-ver">Chromium: {{ site.current_chrome }}</span>
             <span class="dep-ver">V8: {{ site.current_v8 }}</span>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "url": "https://github.com/atom/electron.atom.io/issues"
   },
   "scripts": {
-    "test": "tape spec/*.js | tap-spec"
+    "test": "tape spec/*.js | tap-spec",
+    "rels-vers": "script/releases && script/versions"
   },
   "homepage": "http://electron.atom.io",
   "dependencies": {

--- a/script/versions
+++ b/script/versions
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+var fs = require('fs')
+var request = require('request')
+var yaml = require('yamljs')
+
+var url = 'https://atom.io/download/atom-shell/index.json'
+
+request(url, function (error, response, body) {
+  if (error) return console.log(error)
+  if (response.statusCode == 200) {
+    var data = JSON.parse(response.body)
+
+    var versions = {}
+    versions.node = data[0].node
+    versions.v8 = data[0].v8
+    versions.chrome = data[0].chrome
+
+    updateConfig(versions)
+  }
+})
+
+function updateConfig (versions) {
+  var config = yaml.load('_config.yml')
+  config.current_node = versions.node
+  config.current_v8 = versions.v8
+  config.current_chrome = versions.chrome
+  fs.writeFileSync('_config.yml', yaml.stringify(config))
+}

--- a/script/versions
+++ b/script/versions
@@ -17,6 +17,8 @@ request(url, function (error, response, body) {
     versions.chrome = data[0].chrome
 
     updateConfig(versions)
+  } else {
+    return console.log("Bad request: " + response.statusCode)
   }
 })
 


### PR DESCRIPTION
This adds a script and small section to the front page to display what the latest version of Electron is and what versions of Node, Chromium and V8 it's using :computer: 

Currently it'll just be manually run when we do a release (or maybe just `minor` releases) but :soon: I'll put this and the docs and releases data into a single thing that's run after a hook :fishing_pole_and_fish: 

<img width="816" alt="screen shot 2015-11-12 at 9 14 15 pm" src="https://cloud.githubusercontent.com/assets/1305617/11131445/a4edadcc-8982-11e5-8501-22753889e533.png">