### PR TITLE
Create Update All Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,22 @@ $ script/bootstrap
 $ script/server
 ```
 
-#### Documentation
+### CLI for Docs, Releases & Version Information
 
-Documentation is added to the site directly from the `atom/electron` repository's `docs` directory. This is done with [Node.js](http://www.nodejs.org/download) so you'll need that on your system and to install the dependencies used here.
+This site has versioned documentation, recent release change logs and the current versions of Node.js, Chromium and V8 that are used in Electron.
+
+Each of these are updated upon a **minor** release of Electron. They're done so with the command line interface detailed below.
+
+ You'll need [Node.js](http://www.nodejs.org/download) installed on your system in order to use the CLI. Then you can install the dependencies:
 
 ```bash
 $ cd electron.atom.io
 $ npm install
 ```
 
+#### Versioned Documentation
 
-**CLI**
-
-To fetch documentation at a specific version:
+Versions of Electron documentation are fetched from the `atom/electron` repository's `docs` directory. To fetch documentation at a specific version:
 
 ```bash
 $ script/docs <version> [options]
@@ -42,20 +45,40 @@ Options:
 
 `--latest` Set this version as the latest version of documentation
 
-**Testing**
-
-To test the documentation script:
-
-```bash
-$ npm test
-```
-
 #### Release Notes
 
 The most recent release notes from the `atom/electron` repository are made available on the site and can be updated by running:
 
 ```bash
 $ script/releases
+```
+
+#### Updating Node.js, Chromium and V8 Versions in use in Electron
+
+To update the `_config.yml` in this site with the versions of Node.js, Chromium and V8 that the latest [minor release] of Electron is using run:
+
+```bash
+$ script/versions
+```
+
+#### Update all the Things at Once
+
+The scripts above do each task separately but to run all the things at once:
+
+```bash
+$ npm run latest -- <version>
+# Example:
+$ npm run latest -- v0.36.0
+```
+
+_Note_ This assumes version is the latest and sets it as such by default.
+
+**Testing**
+
+To test the documentation script:
+
+```bash
+$ npm test
 ```
 
 ### Contributing

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "scripts": {
     "test": "tape spec/*.js | tap-spec",
-    "rels-vers": "script/releases && script/versions"
+    "rels-vers": "script/releases && script/versions",
+    "docs": "script/docs --latest",
+    "lastest": "npm run rels-vers && npm run docs"
   },
   "homepage": "http://electron.atom.io",
   "dependencies": {

--- a/script/docs
+++ b/script/docs
@@ -14,6 +14,11 @@ var settings = {
 if (args[0] && args[0] !== '--latest') settings.version = args[0]
 if (args[1] && args[1] === '--latest') settings.latest = true
 
+if (args[0] === '--latest') {
+  settings.latest = true
+  settings.version = args[1]
+}
+
 fetchDocs(settings, function callback (error, message) {
   if (error) console.log(error)
   if (message) console.log(message)


### PR DESCRIPTION
This adds a command for updating at once all the things that need to be updated when a minor version of Electron is released. 

- Add a bit of args logic so that I can reverse order of option so that I can make npm scripts work with an argument in the way I need it to
- Update docs
- Add npm scripts

Here's what it'll look like when it runs:

```bash
npm run lastest -- v0.36.0

> electron.atom.io@1.0.0 lastest /Users/jlord/github/electron.atom.io
> npm run rels-vers && npm run docs "v0.36.0"


> electron.atom.io@1.0.0 rels-vers /Users/jlord/github/electron.atom.io
> script/releases && script/versions


> electron.atom.io@1.0.0 docs /Users/jlord/github/electron.atom.io
> script/docs --latest "v0.36.0"

Downloading electron.tar.gz
[=================================================>] 100.0% (1.82 MB/s)
Done! Docs are in /Users/jlord/github/electron.atom.io/_docs/v0.36.0 and /latest.
```

:pizza: :pizza: 

cc @kevinsawicki 