### PR TITLE
Removed Trojan Link

### DIFF
--- a/_docs/latest/tutorial/application-distribution.md
+++ b/_docs/latest/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.24.0/tutorial/application-distribution.md
+++ b/_docs/v0.24.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.25.0/tutorial/application-distribution.md
+++ b/_docs/v0.25.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.26.0/tutorial/application-distribution.md
+++ b/_docs/v0.26.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.27.0/tutorial/application-distribution.md
+++ b/_docs/v0.27.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.28.0/tutorial/application-distribution.md
+++ b/_docs/v0.28.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.29.0/tutorial/application-distribution.md
+++ b/_docs/v0.29.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.30.0/tutorial/application-distribution.md
+++ b/_docs/v0.30.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.31.0/tutorial/application-distribution-es.md
+++ b/_docs/v0.31.0/tutorial/application-distribution-es.md
@@ -66,7 +66,7 @@ antes de realizar la distribución.
 ### Windows
 
 Puedes renombrar `electron.exe` a cualquier nombre que desees, y editar su ícono y otras informaciones
-con herramientas como [rcedit](https://github.com/atom/rcedit) o [ResEdit](http://www.resedit.net).
+con herramientas como [rcedit](https://github.com/atom/rcedit) o .
 
 ### OS X
 

--- a/_docs/v0.31.0/tutorial/application-distribution.md
+++ b/_docs/v0.31.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.32.0/tutorial/application-distribution.md
+++ b/_docs/v0.32.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.33.0/tutorial/application-distribution.md
+++ b/_docs/v0.33.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.34.0/tutorial/application-distribution.md
+++ b/_docs/v0.34.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.35.0/tutorial/application-distribution.md
+++ b/_docs/v0.35.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.36.0/tutorial/application-distribution.md
+++ b/_docs/v0.36.0/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.36.3/tutorial/application-distribution.md
+++ b/_docs/v0.36.3/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.36.4/tutorial/application-distribution.md
+++ b/_docs/v0.36.4/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 

--- a/_docs/v0.36.5/tutorial/application-distribution.md
+++ b/_docs/v0.36.5/tutorial/application-distribution.md
@@ -68,8 +68,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit) or
-[ResEdit](http://www.resedit.net).
+information with tools like [rcedit](https://github.com/atom/rcedit).
 
 ### OS X
 


### PR DESCRIPTION
- Apparently ResEdit now comes bundled with undesirable executables, so let's remove the recommendation.
- Closes atom/electron#4357