### PR TITLE
Parse Documentation for Footer Links

### DIFF
--- a/lib/doc-links.js
+++ b/lib/doc-links.js
@@ -8,7 +8,7 @@ var path = require('path')
 // to other pages within the docs (relative links,
 // rather than external).
 //
-// We're looking for these patterns:
+// We're looking for these patterns in trandional markdown link syntax:
 // - [words](../abc/abc.md)
 // - [words](../abc/abc)
 // - [words](abc)
@@ -17,6 +17,17 @@ var path = require('path')
 // - [words](../abc/abc.html)
 // - [words](/abc/abc.html)
 // - [words](_abc/abc/abc.html)
+//
+// And these in inline footer link syntax:
+// - [words]: ../abc/abc.md
+// - [words]: ../abc/abc
+// - [words]: abc
+// - [words]: abc.md
+// - [words]: #abc-efg
+// - [words]: ../abc/abc.html
+// - [words]: /abc/abc.html
+// - [words]: _abc/abc/abc.html
+
 
 module.exports = function fixLinks (dir, version, callback) {
   var filesWithLinks = 0
@@ -36,10 +47,14 @@ module.exports = function fixLinks (dir, version, callback) {
   })
 
   function findLinks (file, i) {
-    var urlRegex = /\[.+\]\((?!http)(.+)\)/g
+    var tradRegex = /\[.+\]\((?!http)(.+)\)/g
+    var footRegex = /\[[^\]]+\]:\s+((?!http).+)/g
     var content = fs.readFileSync(file).toString()
-    var links = content.match(urlRegex)
-    if (links) {
+    var tradLinks = content.match(tradRegex) || []
+    var footLinks = content.match(footRegex) || []
+    var links = tradLinks.concat(footLinks)
+
+    if (links.length > 0) {
       filesWithLinks++
       fixInternalLinks(file, content, links)
     }
@@ -50,26 +65,40 @@ module.exports = function fixLinks (dir, version, callback) {
     var baseUrl = 'electron.atom.io/docs/' + version
 
     var newLinks = links.map(function fixLinks (link, i) {
-      var parts = link.split('](')
-      var href = parts[1]
-      href = href.slice(0, href.length - 1)
-      var bracket = parts[0] + ']'
+      var tradLinkStyle = true
+      var parts
+      var bracket
+
+      if (link.match(/\]\(/)) {
+        parts = link.split('](')
+      } else {
+        parts = link.split(']:')
+        tradLinkStyle = false
+      }
+      var href = parts[1].trim()
+      if (tradLinkStyle) href = href.slice(0, href.length - 1)
+
+      if (tradLinkStyle) bracket = parts[0] + ']'
+      else bracket = parts[0] + ']: '
 
       if (href.match(/\.md/ig)) {
         var newLink = href.replace(/\.md/ig, '')
         if (newLink.indexOf('../') > -1) {
           newLink = 'http://' + path.join(baseUrl, newLink.replace('../', '')).split(path.sep).join('/')
-          var newMdLink = bracket + '(' + newLink + ')'
+          if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
+          else newMdLink = bracket + newLink
           return newMdLink
         } else if (newLink.indexOf('./') > -1) {
           var fileDir = getFileDir(file)
           newLink = 'http://' + path.join(baseUrl, fileDir, newLink).split(path.sep).join('/')
-          newMdLink = bracket + '(' + newLink + ')'
+          if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
+          else newMdLink = bracket + newLink
           return newMdLink
         } else if (newLink.indexOf('/') < 0) {
           fileDir = getFileDir(file)
           newLink = 'http://' + path.join(baseUrl, fileDir, newLink).split(path.sep).join('/')
-          newMdLink = bracket + '(' + newLink + ')'
+          if (tradLinkStyle) newMdLink = bracket + '(' + newLink + ')'
+          else newMdLink = bracket + newLink
           return newMdLink
         }
         return newLink
@@ -83,7 +112,7 @@ module.exports = function fixLinks (dir, version, callback) {
     var array = p.split(path.sep)
     return array[array.length - 2]
   }
-  
+
   function replaceLinksInContent (file, content, oldLinks, newLinks) {
     oldLinks.forEach(function (oldLink, i) {
       content = content.replace(oldLink, newLinks[i])

--- a/lib/fetch-docs.js
+++ b/lib/fetch-docs.js
@@ -25,7 +25,7 @@ module.exports = function fetchDocs (settings, callback) {
   updateVersions(settings)
 
   var url = 'https://api.github.com/repos/atom/electron/tarball/' + settings.version
-  settings.tmpDir = path.join(os.tmpDir(), 'electron-tmp-download')
+  settings.tmpDir = path.join(os.tmpDir(), Math.random() + '-electron-tmp-download')
 
   // Create temp directory to fetch tarball into
   mkdir(settings.tmpDir, function (error) {
@@ -39,7 +39,6 @@ module.exports = function fetchDocs (settings, callback) {
       },
       target: filename,
       dir: settings.tmpDir,
-      resume: true,
       verbose: true
       }
 

--- a/spec/fixtures/doc-with-internal-links.md
+++ b/spec/fixtures/doc-with-internal-links.md
@@ -158,3 +158,19 @@ $ ./Electron.app/Contents/MacOS/Electron your-app/
 
 `Electron.app` here is part of the Electron's release package, you can download
 it from [here](https://github.com/atom/electron/releases).
+
+### Windows
+
+* On Windows 10, notifications "just work".
+* On Windows 8.1 and Windows 8, a shortcut to your app, with a [Application User
+Model ID][app-user-model-id], must be installed to the Start screen. Note,
+however, that it does not need to be pinned to the Start screen.
+* On Windows 7 and below, notifications are not supported. You can however send
+"balloon notifications" using the [Tray API][tray-balloon].
+
+Furthermore, the maximum length for the notification body is 250 characters,
+with the Windows team recommending that notifications should be kept to 200
+characters.
+
+[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx

--- a/spec/fixtures/test-set-docs/tutorial/quick-start.md
+++ b/spec/fixtures/test-set-docs/tutorial/quick-start.md
@@ -158,3 +158,19 @@ $ ./Electron.app/Contents/MacOS/Electron your-app/
 
 `Electron.app` here is part of the Electron's release package, you can download
 it from [here](https://github.com/atom/electron/releases).
+
+### Windows
+
+* On Windows 10, notifications "just work".
+* On Windows 8.1 and Windows 8, a shortcut to your app, with a [Application User
+Model ID][app-user-model-id], must be installed to the Start screen. Note,
+however, that it does not need to be pinned to the Start screen.
+* On Windows 7 and below, notifications are not supported. You can however send
+"balloon notifications" using the [Tray API][tray-balloon].
+
+Furthermore, the maximum length for the notification body is 250 characters,
+with the Windows team recommending that notifications should be kept to 200
+characters.
+
+[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx

--- a/spec/link-fixing.js
+++ b/spec/link-fixing.js
@@ -5,7 +5,8 @@ var test = require('tape')
 
 var fixInternalLinks = require('../lib/doc-links.js')
 
-var urlRegex = /\[.+\]\(.+\)/g
+var tradRegex = /\[.+\]\(.+\)/g
+var footRegex = /\[[^\]]+\]:\s(.+)/g
 
 var dir = 'spec/fixtures/test-set-docs/tutorial'
 var emptyDir = 'spec/fixtures/test-set-docs/empty-dir'
@@ -17,11 +18,13 @@ var expectedLinks = [
   '[ipc](http://electron.atom.io/docs/v0.27.0/api/ipc-renderer)',
   '[remote](http://electron.atom.io/docs/v0.27.0/api/remote)',
   '[Application distribution](http://electron.atom.io/docs/v0.27.0/tutorial/application-distribution)',
-  '[here](https://github.com/atom/electron/releases)'
+  '[here](https://github.com/atom/electron/releases)',
+  '[tray-balloon]: http://electron.atom.io/docs/v0.27.0/api/tray#traydisplayballoonoptions-windows',
+  '[app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx'
   ]
 
 test('Fetch and write documentation with latest flag', function (t) {
-  t.plan(4)
+  t.plan(6)
 
   fixInternalLinks(dir, 'v0.27.0', function callback (error, message) {
     if (error) return t.fail(error)
@@ -30,11 +33,12 @@ test('Fetch and write documentation with latest flag', function (t) {
 
   function compareLinks () {
     var finalContent = fs.readFileSync(finalFile).toString()
-    var finalLinks = finalContent.match(urlRegex)
-
+    var tradLinks = finalContent.match(tradRegex) || []
+    var footLinks = finalContent.match(footRegex) || []
+    var finalLinks = tradLinks.concat(footLinks)
     if (finalLinks) {
-      finalLinks.forEach(function (finalLink, i) {
-        t.equal(finalLink, expectedLinks[i], 'Link ' + finalLink + ' matches ' + expectedLinks[i])
+      expectedLinks.forEach(function (expectedLink, i) {
+        t.equal(finalLinks[i], expectedLink, 'Link ' + expectedLink + ' matches ' + finalLinks[i])
       })
     }
     cleanup()


### PR DESCRIPTION
All of the Electron documentation hosted in the repository on github.com is written in markdown and github.com handles any relative links to work correctly on the site.

We use the same docs here on this site so we need to parse for any links and make them work here, too. This pull request updates the parsing so that two forms of markdown links are acceptable. 

- Traditional: (in the body) `[i am a link](github.com)`
- Footer: (in the body) `[i am a link][i-am-link]` (in the footer) `[i-am-link]: https://github.com`

Specs are updated as well :pizza: 

cc @kevinsawicki :pear: 