### PR TITLE
Fix older links

### DIFF
--- a/_docs/v0.24.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.24.0/api/chrome-command-line-switches.md
@@ -61,9 +61,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.24.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.24.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.24.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.24.0/tutorial/application-distribution.md
+++ b/_docs/v0.24.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.24.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.24.0/tutorial/desktop-environment-integration.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.24.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.24.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.24.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.24.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.24.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.24.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.25.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.25.0/api/chrome-command-line-switches.md
@@ -61,9 +61,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.25.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.25.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.25.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.25.0/tutorial/application-distribution.md
+++ b/_docs/v0.25.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.25.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.25.0/tutorial/desktop-environment-integration.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.25.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.25.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.25.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.25.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.25.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.25.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.26.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.26.0/api/chrome-command-line-switches.md
@@ -61,9 +61,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.26.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.26.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.26.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.26.0/tutorial/application-distribution.md
+++ b/_docs/v0.26.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.26.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.26.0/tutorial/desktop-environment-integration.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.26.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.26.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.26.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.26.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.26.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.26.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.27.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.27.0/api/chrome-command-line-switches.md
@@ -61,9 +61,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.27.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.27.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.27.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.27.0/tutorial/application-distribution.md
+++ b/_docs/v0.27.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.27.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.27.0/tutorial/desktop-environment-integration.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.27.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.27.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.27.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.27.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.27.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.27.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.28.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.28.0/api/chrome-command-line-switches.md
@@ -66,9 +66,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.28.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.28.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.28.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.28.0/tutorial/application-distribution.md
+++ b/_docs/v0.28.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.28.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.28.0/tutorial/desktop-environment-integration.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.28.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.28.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.28.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.28.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.28.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.28.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.29.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.29.0/api/chrome-command-line-switches.md
@@ -70,9 +70,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.29.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.29.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.29.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.29.0/tutorial/application-distribution.md
+++ b/_docs/v0.29.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.29.0/tutorial/desktop-environment-integration-ko.md
+++ b/_docs/v0.29.0/tutorial/desktop-environment-integration-ko.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app-ko.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app-ko.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app-ko.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window-ko.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window-ko.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window-ko.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.29.0/api/app-ko#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.29.0/api/app-ko#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.29.0/api/app-ko#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.29.0/api/browser-window-ko#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.29.0/api/browser-window-ko#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.29.0/api/browser-window-ko#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.29.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.29.0/tutorial/desktop-environment-integration.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.29.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.29.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.29.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.29.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.29.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.29.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.30.0/api/chrome-command-line-switches-ko.md
+++ b/_docs/v0.30.0/api/chrome-command-line-switches-ko.md
@@ -70,9 +70,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app-ko.md
-[append-switch]: app-ko.md#appcommandlineappendswitchswitch-value
-[ready]: app-ko.md#event-ready
+[app]: http://electron.atom.io/docs/v0.30.0/api/app-ko
+[append-switch]: http://electron.atom.io/docs/v0.30.0/api/app-ko#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.30.0/api/app-ko#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.30.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.30.0/api/chrome-command-line-switches.md
@@ -74,9 +74,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.30.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.30.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.30.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.30.0/tutorial/application-distribution.md
+++ b/_docs/v0.30.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.30.0/tutorial/desktop-environment-integration-ko.md
+++ b/_docs/v0.30.0/tutorial/desktop-environment-integration-ko.md
@@ -169,11 +169,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app-ko.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app-ko.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app-ko.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window-ko.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window-ko.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window-ko.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.30.0/api/app-ko#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.30.0/api/app-ko#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.30.0/api/app-ko#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.30.0/api/browser-window-ko#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.30.0/api/browser-window-ko#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.30.0/api/browser-window-ko#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.30.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.30.0/tutorial/desktop-environment-integration.md
@@ -198,11 +198,11 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.30.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.30.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.30.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.30.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.30.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.30.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.31.0/api/chrome-command-line-switches-ko.md
+++ b/_docs/v0.31.0/api/chrome-command-line-switches-ko.md
@@ -69,9 +69,9 @@ Hostname 맵핑 규칙을 설정합니다. (`,`로 분리)
 
 `--host-rules` 플래그와 비슷하지만 이 플래그는 host resolver에만 적용됩니다.
 
-[app]: app-ko.md
-[append-switch]: app-ko.md#appcommandlineappendswitchswitch-value
-[ready]: app-ko.md#event-ready
+[app]: http://electron.atom.io/docs/v0.31.0/api/app-ko
+[append-switch]: http://electron.atom.io/docs/v0.31.0/api/app-ko#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.31.0/api/app-ko#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.31.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.31.0/api/chrome-command-line-switches.md
@@ -74,9 +74,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.31.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.31.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.31.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.31.0/tutorial/application-distribution-es.md
+++ b/_docs/v0.31.0/tutorial/application-distribution-es.md
@@ -66,7 +66,7 @@ antes de realizar la distribución.
 ### Windows
 
 Puedes renombrar `electron.exe` a cualquier nombre que desees, y editar su ícono y otras informaciones
-con herramientas como [rcedit](https://github.com/atom/rcedit) o .
+con herramientas como [rcedit](https://github.com/atom/rcedit) o [ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.31.0/tutorial/application-distribution.md
+++ b/_docs/v0.31.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.31.0/tutorial/desktop-environment-integration-es.md
+++ b/_docs/v0.31.0/tutorial/desktop-environment-integration-es.md
@@ -168,11 +168,11 @@ var window = new BrowserWindow({...});
 window.setProgressBar(0.5);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.31.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.31.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.31.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher

--- a/_docs/v0.31.0/tutorial/desktop-environment-integration-ko.md
+++ b/_docs/v0.31.0/tutorial/desktop-environment-integration-ko.md
@@ -218,12 +218,12 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app-ko.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app-ko.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app-ko.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window-ko.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window-ko.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window-ko.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.31.0/api/app-ko#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.31.0/api/app-ko#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.31.0/api/app-ko#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.31.0/api/browser-window-ko#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.31.0/api/browser-window-ko#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.31.0/api/browser-window-ko#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetthumbarbuttonsbuttons

--- a/_docs/v0.31.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.31.0/tutorial/desktop-environment-integration.md
@@ -251,12 +251,12 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.31.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.31.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.31.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.31.0/api/browser-window#browserwindowsetthumbarbuttonsbuttons

--- a/_docs/v0.32.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.32.0/api/chrome-command-line-switches.md
@@ -74,9 +74,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.32.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.32.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.32.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.32.0/tutorial/application-distribution.md
+++ b/_docs/v0.32.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.32.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.32.0/tutorial/desktop-environment-integration.md
@@ -250,12 +250,12 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.32.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.32.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.32.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.32.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.32.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.32.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.32.0/api/browser-window#browserwindowsetthumbarbuttonsbuttons

--- a/_docs/v0.33.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.33.0/api/chrome-command-line-switches.md
@@ -74,9 +74,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.33.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.33.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.33.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.33.0/tutorial/application-distribution.md
+++ b/_docs/v0.33.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.33.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.33.0/tutorial/desktop-environment-integration.md
@@ -250,12 +250,12 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.33.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.33.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.33.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.33.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.33.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.33.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.33.0/api/browser-window#browserwindowsetthumbarbuttonsbuttons

--- a/_docs/v0.34.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.34.0/api/chrome-command-line-switches.md
@@ -74,9 +74,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.34.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.34.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.34.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.34.0/tutorial/application-distribution.md
+++ b/_docs/v0.34.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.34.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.34.0/tutorial/desktop-environment-integration.md
@@ -250,12 +250,12 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.34.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.34.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.34.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.34.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.34.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.34.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.34.0/api/browser-window#browserwindowsetthumbarbuttonsbuttons

--- a/_docs/v0.35.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.35.0/api/chrome-command-line-switches.md
@@ -85,9 +85,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.35.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.35.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.35.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.35.0/api/ipc-main.md
+++ b/_docs/v0.35.0/api/ipc-main.md
@@ -75,4 +75,4 @@ Returns the `webContents` that sent the message, you can call
 `event.sender.send` to reply to the asynchronous message, see
 [webContents.send][webcontents-send] for more information.
 
-[webcontents-send]: web-contents.md#webcontentssendchannel-args
+[webcontents-send]: http://electron.atom.io/docs/v0.35.0/api/web-contents#webcontentssendchannel-args

--- a/_docs/v0.35.0/api/synopsis.md
+++ b/_docs/v0.35.0/api/synopsis.md
@@ -86,6 +86,6 @@ require('electron').hideInternalModules()
 ```
 
 [gui]: https://en.wikipedia.org/wiki/Graphical_user_interface
-[main-process]: ../tutorial/quick-start.md#the-main-process
+[main-process]: http://electron.atom.io/docs/v0.35.0/tutorial/quick-start#the-main-process
 [desctructuring-assignment]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
 [issue-387]: https://github.com/atom/electron/issues/387

--- a/_docs/v0.35.0/tutorial/application-distribution.md
+++ b/_docs/v0.35.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.35.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.35.0/tutorial/desktop-environment-integration.md
@@ -313,15 +313,15 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.35.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.35.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.35.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.35.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.35.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.35.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.35.0/api/browser-window#browserwindowsetthumbarbuttonsbuttons
+[tray-balloon]: http://electron.atom.io/docs/v0.35.0/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.0/api/chrome-command-line-switches.md
+++ b/_docs/v0.36.0/api/chrome-command-line-switches.md
@@ -101,9 +101,9 @@ connection, and the endpoint host in a `SOCKS` proxy connection).
 
 Like `--host-rules` but these `rules` only apply to the host resolver.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.36.0/api/app
+[append-switch]: http://electron.atom.io/docs/v0.36.0/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.36.0/api/app#event-ready
 
 ## --ignore-certificate-errors
 

--- a/_docs/v0.36.0/api/ipc-main.md
+++ b/_docs/v0.36.0/api/ipc-main.md
@@ -75,4 +75,4 @@ Returns the `webContents` that sent the message, you can call
 `event.sender.send` to reply to the asynchronous message, see
 [webContents.send][webcontents-send] for more information.
 
-[webcontents-send]: web-contents.md#webcontentssendchannel-arg1-arg2-
+[webcontents-send]: http://electron.atom.io/docs/v0.36.0/api/web-contents#webcontentssendchannel-arg1-arg2-

--- a/_docs/v0.36.0/api/synopsis.md
+++ b/_docs/v0.36.0/api/synopsis.md
@@ -86,6 +86,6 @@ require('electron').hideInternalModules()
 ```
 
 [gui]: https://en.wikipedia.org/wiki/Graphical_user_interface
-[main-process]: ../tutorial/quick-start.md#the-main-process
+[main-process]: http://electron.atom.io/docs/v0.36.0/tutorial/quick-start#the-main-process
 [desctructuring-assignment]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
 [issue-387]: https://github.com/atom/electron/issues/387

--- a/_docs/v0.36.0/tutorial/application-distribution.md
+++ b/_docs/v0.36.0/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.36.0/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.36.0/tutorial/desktop-environment-integration.md
@@ -313,15 +313,15 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.36.0/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.36.0/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.36.0/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.36.0/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.36.0/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.36.0/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.36.0/api/browser-window#browserwindowsetthumbarbuttonsbuttons
+[tray-balloon]: http://electron.atom.io/docs/v0.36.0/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.3/api/chrome-command-line-switches.md
+++ b/_docs/v0.36.3/api/chrome-command-line-switches.md
@@ -162,7 +162,7 @@ logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.36.3/api/app
+[append-switch]: http://electron.atom.io/docs/v0.36.3/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.36.3/api/app#event-ready
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files

--- a/_docs/v0.36.3/api/synopsis.md
+++ b/_docs/v0.36.3/api/synopsis.md
@@ -86,6 +86,6 @@ require('electron').hideInternalModules()
 ```
 
 [gui]: https://en.wikipedia.org/wiki/Graphical_user_interface
-[main-process]: ../tutorial/quick-start.md#the-main-process
+[main-process]: http://electron.atom.io/docs/v0.36.3/tutorial/quick-start#the-main-process
 [desctructuring-assignment]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
 [issue-387]: https://github.com/atom/electron/issues/387

--- a/_docs/v0.36.3/tutorial/application-distribution.md
+++ b/_docs/v0.36.3/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.36.3/tutorial/debugging-main-process.md
+++ b/_docs/v0.36.3/tutorial/debugging-main-process.md
@@ -79,5 +79,5 @@ Open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858 in the Chrome brows
 
 [node-inspector]: https://github.com/node-inspector/node-inspector
 [node-gyp-required-tools]: https://github.com/nodejs/node-gyp#installation
-[how-to-install-native-modules]: using-native-node-modules.md#how-to-install-native-modules
+[how-to-install-native-modules]: http://electron.atom.io/docs/v0.36.3/tutorial/using-native-node-modules#how-to-install-native-modules
 

--- a/_docs/v0.36.3/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.36.3/tutorial/desktop-environment-integration.md
@@ -313,15 +313,15 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.36.3/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.36.3/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.36.3/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.36.3/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.36.3/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.36.3/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.36.3/api/browser-window#browserwindowsetthumbarbuttonsbuttons
+[tray-balloon]: http://electron.atom.io/docs/v0.36.3/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.4/api/chrome-command-line-switches.md
+++ b/_docs/v0.36.4/api/chrome-command-line-switches.md
@@ -162,7 +162,7 @@ logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.36.4/api/app
+[append-switch]: http://electron.atom.io/docs/v0.36.4/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.36.4/api/app#event-ready
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files

--- a/_docs/v0.36.4/api/synopsis.md
+++ b/_docs/v0.36.4/api/synopsis.md
@@ -86,6 +86,6 @@ require('electron').hideInternalModules()
 ```
 
 [gui]: https://en.wikipedia.org/wiki/Graphical_user_interface
-[main-process]: ../tutorial/quick-start.md#the-main-process
+[main-process]: http://electron.atom.io/docs/v0.36.4/tutorial/quick-start#the-main-process
 [desctructuring-assignment]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
 [issue-387]: https://github.com/atom/electron/issues/387

--- a/_docs/v0.36.4/tutorial/application-distribution.md
+++ b/_docs/v0.36.4/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.36.4/tutorial/debugging-main-process.md
+++ b/_docs/v0.36.4/tutorial/debugging-main-process.md
@@ -79,5 +79,5 @@ Open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858 in the Chrome brows
 
 [node-inspector]: https://github.com/node-inspector/node-inspector
 [node-gyp-required-tools]: https://github.com/nodejs/node-gyp#installation
-[how-to-install-native-modules]: using-native-node-modules.md#how-to-install-native-modules
+[how-to-install-native-modules]: http://electron.atom.io/docs/v0.36.4/tutorial/using-native-node-modules#how-to-install-native-modules
 

--- a/_docs/v0.36.4/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.36.4/tutorial/desktop-environment-integration.md
@@ -301,15 +301,15 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.36.4/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.36.4/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.36.4/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.36.4/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.36.4/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.36.4/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.36.4/api/browser-window#browserwindowsetthumbarbuttonsbuttons
+[tray-balloon]: http://electron.atom.io/docs/v0.36.4/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.5/api/chrome-command-line-switches.md
+++ b/_docs/v0.36.5/api/chrome-command-line-switches.md
@@ -162,7 +162,7 @@ logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.36.5/api/app
+[append-switch]: http://electron.atom.io/docs/v0.36.5/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.36.5/api/app#event-ready
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files

--- a/_docs/v0.36.5/tutorial/application-distribution.md
+++ b/_docs/v0.36.5/tutorial/application-distribution.md
@@ -68,7 +68,8 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/atom/rcedit) or
+[ResEdit](http://www.resedit.net).
 
 ### OS X
 

--- a/_docs/v0.36.5/tutorial/debugging-main-process.md
+++ b/_docs/v0.36.5/tutorial/debugging-main-process.md
@@ -79,5 +79,5 @@ Open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858 in the Chrome brows
 
 [node-inspector]: https://github.com/node-inspector/node-inspector
 [node-gyp-required-tools]: https://github.com/nodejs/node-gyp#installation
-[how-to-install-native-modules]: using-native-node-modules.md#how-to-install-native-modules
+[how-to-install-native-modules]: http://electron.atom.io/docs/v0.36.5/tutorial/using-native-node-modules#how-to-install-native-modules
 

--- a/_docs/v0.36.5/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.36.5/tutorial/desktop-environment-integration.md
@@ -301,15 +301,15 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.36.5/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.36.5/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.36.5/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.36.5/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.36.5/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.36.5/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.36.5/api/browser-window#browserwindowsetthumbarbuttonsbuttons
+[tray-balloon]: http://electron.atom.io/docs/v0.36.5/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.6/api/chrome-command-line-switches.md
+++ b/_docs/v0.36.6/api/chrome-command-line-switches.md
@@ -162,7 +162,7 @@ logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.36.6/api/app
+[append-switch]: http://electron.atom.io/docs/v0.36.6/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.36.6/api/app#event-ready
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files

--- a/_docs/v0.36.6/tutorial/debugging-main-process.md
+++ b/_docs/v0.36.6/tutorial/debugging-main-process.md
@@ -79,5 +79,5 @@ Open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858 in the Chrome brows
 
 [node-inspector]: https://github.com/node-inspector/node-inspector
 [node-gyp-required-tools]: https://github.com/nodejs/node-gyp#installation
-[how-to-install-native-modules]: using-native-node-modules.md#how-to-install-native-modules
+[how-to-install-native-modules]: http://electron.atom.io/docs/v0.36.6/tutorial/using-native-node-modules#how-to-install-native-modules
 

--- a/_docs/v0.36.6/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.36.6/tutorial/desktop-environment-integration.md
@@ -301,15 +301,15 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.36.6/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.36.6/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.36.6/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.36.6/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.36.6/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.36.6/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.36.6/api/browser-window#browserwindowsetthumbarbuttonsbuttons
+[tray-balloon]: http://electron.atom.io/docs/v0.36.6/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.7/api/chrome-command-line-switches.md
+++ b/_docs/v0.36.7/api/chrome-command-line-switches.md
@@ -162,7 +162,7 @@ logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.36.7/api/app
+[append-switch]: http://electron.atom.io/docs/v0.36.7/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.36.7/api/app#event-ready
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files

--- a/_docs/v0.36.7/tutorial/debugging-main-process.md
+++ b/_docs/v0.36.7/tutorial/debugging-main-process.md
@@ -79,5 +79,5 @@ Open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858 in the Chrome brows
 
 [node-inspector]: https://github.com/node-inspector/node-inspector
 [node-gyp-required-tools]: https://github.com/nodejs/node-gyp#installation
-[how-to-install-native-modules]: using-native-node-modules.md#how-to-install-native-modules
+[how-to-install-native-modules]: http://electron.atom.io/docs/v0.36.7/tutorial/using-native-node-modules#how-to-install-native-modules
 

--- a/_docs/v0.36.7/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.36.7/tutorial/desktop-environment-integration.md
@@ -301,15 +301,15 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks
-[setprogressbar]: ../api/browser-window.md#browserwindowsetprogressbarprogress
-[setrepresentedfilename]: ../api/browser-window.md#browserwindowsetrepresentedfilenamefilename
-[setdocumentedited]: ../api/browser-window.md#browserwindowsetdocumenteditededited
+[addrecentdocument]: http://electron.atom.io/docs/v0.36.7/api/app#appaddrecentdocumentpath
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.36.7/api/app#appclearrecentdocuments
+[setusertaskstasks]: http://electron.atom.io/docs/v0.36.7/api/app#appsetusertaskstasks
+[setprogressbar]: http://electron.atom.io/docs/v0.36.7/api/browser-window#browserwindowsetprogressbarprogress
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.36.7/api/browser-window#browserwindowsetrepresentedfilenamefilename
+[setdocumentedited]: http://electron.atom.io/docs/v0.36.7/api/browser-window#browserwindowsetdocumenteditededited
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#browserwindowsetthumbarbuttonsbuttons
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.36.7/api/browser-window#browserwindowsetthumbarbuttonsbuttons
+[tray-balloon]: http://electron.atom.io/docs/v0.36.7/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.8/api/chrome-command-line-switches.md
+++ b/_docs/v0.36.8/api/chrome-command-line-switches.md
@@ -162,7 +162,7 @@ logging level for all code in the source files under a `foo/bar` directory.
 
 This switch only works when `--enable-logging` is also passed.
 
-[app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
-[ready]: app.md#event-ready
+[app]: http://electron.atom.io/docs/v0.36.8/api/app
+[append-switch]: http://electron.atom.io/docs/v0.36.8/api/app#appcommandlineappendswitchswitch-value
+[ready]: http://electron.atom.io/docs/v0.36.8/api/app#event-ready
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files

--- a/_docs/v0.36.8/api/ipc-main.md
+++ b/_docs/v0.36.8/api/ipc-main.md
@@ -99,4 +99,4 @@ Returns the `webContents` that sent the message, you can call
 `event.sender.send` to reply to the asynchronous message, see
 [webContents.send][web-contents-send] for more information.
 
-[web-contents-send]: web-contents.md#webcontentssendchannel-arg1-arg2-
+[web-contents-send]: http://electron.atom.io/docs/v0.36.8/api/web-contents#webcontentssendchannel-arg1-arg2-

--- a/_docs/v0.36.8/tutorial/debugging-main-process.md
+++ b/_docs/v0.36.8/tutorial/debugging-main-process.md
@@ -79,5 +79,5 @@ Open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858 in the Chrome brows
 
 [node-inspector]: https://github.com/node-inspector/node-inspector
 [node-gyp-required-tools]: https://github.com/nodejs/node-gyp#installation
-[how-to-install-native-modules]: using-native-node-modules.md#how-to-install-native-modules
+[how-to-install-native-modules]: http://electron.atom.io/docs/v0.36.8/tutorial/using-native-node-modules#how-to-install-native-modules
 

--- a/_docs/v0.36.8/tutorial/desktop-environment-integration.md
+++ b/_docs/v0.36.8/tutorial/desktop-environment-integration.md
@@ -328,16 +328,16 @@ window.setRepresentedFilename('/etc/passwd');
 window.setDocumentEdited(true);
 ```
 
-[addrecentdocument]: ../api/app.md#appaddrecentdocumentpath-os-x-windows
-[clearrecentdocuments]: ../api/app.md#appclearrecentdocuments-os-x-windows
-[setusertaskstasks]: ../api/app.md#appsetusertaskstasks-windows
-[setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress
-[setoverlayicon]: ../api/browser-window.md#winsetoverlayiconoverlay-description-windows-7
-[setrepresentedfilename]: ../api/browser-window.md#winsetrepresentedfilenamefilename-os-x
-[setdocumentedited]: ../api/browser-window.md#winsetdocumenteditededited-os-x
+[addrecentdocument]: http://electron.atom.io/docs/v0.36.8/api/app#appaddrecentdocumentpath-os-x-windows
+[clearrecentdocuments]: http://electron.atom.io/docs/v0.36.8/api/app#appclearrecentdocuments-os-x-windows
+[setusertaskstasks]: http://electron.atom.io/docs/v0.36.8/api/app#appsetusertaskstasks-windows
+[setprogressbar]: http://electron.atom.io/docs/v0.36.8/api/browser-window#winsetprogressbarprogress
+[setoverlayicon]: http://electron.atom.io/docs/v0.36.8/api/browser-window#winsetoverlayiconoverlay-description-windows-7
+[setrepresentedfilename]: http://electron.atom.io/docs/v0.36.8/api/browser-window#winsetrepresentedfilenamefilename-os-x
+[setdocumentedited]: http://electron.atom.io/docs/v0.36.8/api/browser-window#winsetdocumenteditededited-os-x
 [app-registration]: http://msdn.microsoft.com/en-us/library/windows/desktop/ee872121(v=vs.85).aspx
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
-[setthumbarbuttons]: ../api/browser-window.md#winsetthumbarbuttonsbuttons-windows-7
-[tray-balloon]: ../api/tray.md#traydisplayballoonoptions-windows
+[setthumbarbuttons]: http://electron.atom.io/docs/v0.36.8/api/browser-window#winsetthumbarbuttonsbuttons-windows-7
+[tray-balloon]: http://electron.atom.io/docs/v0.36.8/api/tray#traydisplayballoonoptions-windows
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [notification-spec]: https://developer.gnome.org/notification-spec/

--- a/_docs/v0.36.8/tutorial/quick-start.md
+++ b/_docs/v0.36.8/tutorial/quick-start.md
@@ -215,4 +215,4 @@ $ cd electron-quick-start
 $ npm install && npm start
 ```
 
-[share-data]: ../faq/electron-faq.md#how-to-share-data-between-web-pages
+[share-data]: http://electron.atom.io/docs/v0.36.8/faq/electron-faq#how-to-share-data-between-web-pages


### PR DESCRIPTION
This pull request goes back through the previous versions available on the site and runs the updated markdown link parser on them so that their footer links are handled correctly :link: :cake: 