### PR TITLE
add link to /docs/all

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -37,6 +37,9 @@ layout: page
         <br>
         <span class="octicon octicon-zap"></span>
         Need a different version of the docs? See the <a href='/docs'>available versions</a>.
+        <br>
+        <span class="octicon octicon-book"></span>
+        Want to search all the documentation at once? See the <a href='/docs/all'>single-page docs</a>.
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
http://electron.atom.io/docs/all is a thing! This adds a link to it in the docs footer:

![screen shot 2016-03-23 at 3 27 20 pm](https://cloud.githubusercontent.com/assets/2289/14002838/c3404e9c-f10b-11e5-93e8-8f89b18babc9.png)

The icon layout needs a little love, but I'd rather :ship: and save that fix for another PR.